### PR TITLE
rev to base dockerfile to 1.5.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/google_containers/hyperkube-amd64:v1.4.6
+FROM gcr.io/google_containers/hyperkube-amd64:v1.5.3
 
 RUN apt-get update && apt-get install -y make jq && \
     cp /kubectl /usr/local/bin/kubectl && \


### PR DESCRIPTION
while deploying to k8s 1.5.2, I was getting error:
```
error validating "manifests/hdfs-nn-statefulset.yaml": error validating data: API version "apps/v1beta1" isn't supported,
```

until I rev'd the `hyperkube` base to `1.5.3`

---
ps. thanks for this repo - very useful